### PR TITLE
[pkg,util] Add digest generation util

### DIFF
--- a/bin/digest.js
+++ b/bin/digest.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+const {createHash} = require('crypto')
+
+const fsp = fs.promises
+
+function calcHash(alg, filepath) {
+  const hash = createHash(alg)
+
+  const stream = fs.createReadStream(filepath)
+
+  return new Promise((resolve, reject) => {
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('error', reject)
+    stream.on('end', () => {
+      resolve(hash.digest())
+    })
+  })
+}
+
+async function calcHashes(alg, dir, files) {
+  dir = path.resolve(dir)
+  const result = await Promise.all(files.map(async (relPath) => {
+    const filepath = path.resolve(relPath)
+    const digest = await calcHash(alg, filepath)
+
+    const content = {
+      manifest: 'digest-json/v1',
+      alg,
+      digest: `${alg}-${digest.toString('base64')}`,
+    }
+
+    await fsp.writeFile(`${relPath}.digest.json`, JSON.stringify(content, null, 2))
+
+    return [relPath, content]
+  }))
+
+  for (const [file, {digest}] of result) {
+    console.log('%s %s', file, digest)
+  }
+}
+
+calcHashes(process.argv[2], process.cwd(), process.argv.slice(3))
+.catch((error) => {
+  console.error(error)
+
+  return 1
+})
+.then((code = 0) => process.exit(code))

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:iife": "rollup --format iife --name pill -o dist/pill.js src/pill.js",
     "build:cjs": "rollup --format cjs --name pill -o dist/node/pill.js src/pill.js",
     "build:minify": "babel-minify -o dist/pill.min.js dist/pill.js",
-    "build:checksum": "node bin/checksum.js dist dist/*.js > dist/checksum.txt",
+    "build:digest": "node bin/digest.js sha512 dist/*.js",
     "prepublishOnly": "npm run committed && npm run clean && npm run build",
     "lint": "eslint src",
     "lint:staged": "bin/lint-staged.js",


### PR DESCRIPTION
Generate digest files on build step. Previously it was a `checksum.txt` which is actually can be confusing and contained no important information, like hash digest algorithm nor contained properly formatted integrity string.